### PR TITLE
html() returns encoded string to clippy so the incorrect string is copied.

### DIFF
--- a/jquery.clippy.js
+++ b/jquery.clippy.js
@@ -41,7 +41,7 @@ We're using Clippy, found at https://github.com/mojombo/clippy, to make a simple
 			}
 			else
 			{
-				text = $(val).html();
+				text = $(val).text();
 			}
 			
 			// text should be URI-encoded, per https://github.com/mojombo/clippy/pull/9


### PR DESCRIPTION
... you have a url with ampersands, or are trying to copy actual html code (for the user to copy & paste) then it doesn't copy the correct string.
