### PR TITLE
Allow adding more flashvars.

### DIFF
--- a/src/jquery.clippy.js
+++ b/src/jquery.clippy.js
@@ -13,7 +13,8 @@
 			'clippy_path': 'clippy.swf',
 			'keep_text': false,
 			'transparent': false,
-			'force_load' : false
+			'force_load' : false,
+			'flashvars'  : {}
 		};
 		
 		opts = $.extend(_opts, opts);
@@ -74,7 +75,7 @@
 				{
 					$(this).html('');
 				}
-				swfobject.embedSWF(opts.clippy_path, id, opts.width, opts.height, '10', false, {text: text}, {scale: "noscale"});
+				swfobject.embedSWF(opts.clippy_path, id, opts.width, opts.height, '10', false, $.extend(opts.flashvars, {text: text}), {scale: "noscale"});
 			});
 		}
 		else


### PR DESCRIPTION
Required for use with this clippy fork: https://github.com/kneath/clippy which is a nice fork because it allows setting a clippyCopiedCallback JS function (GitHub uses it to change the tooltip text from "copy to clipboard" to "copied!").
